### PR TITLE
Made signature core async

### DIFF
--- a/src/Decos.Http.Signatures.Validation/Decos.Http.Signatures.Validation.csproj
+++ b/src/Decos.Http.Signatures.Validation/Decos.Http.Signatures.Validation.csproj
@@ -8,7 +8,7 @@
     <PackageProjectUrl>https://github.com/DecosInformationSolutions/HttpSignatures</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>A .NET Standard 2.0 library for validating signatures. Typically, the AuthenticationBuilder extension AddSignature would be used to add an ASP.NET Core authentication handler that authenticates requests with a valid signature.</Description>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Decos.Http.Signatures/Decos.Http.Signatures.csproj
+++ b/src/Decos.Http.Signatures/Decos.Http.Signatures.csproj
@@ -9,7 +9,7 @@
     <Description>A .NET Standard 2.0 library for generating signatures on HTTP messages. Typically, the SignatureAuthorizationHandler is used with an HttpClient for signing outgoing requests.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/DecosInformationSolutions/HttpSignatures</PackageProjectUrl>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Decos.Http.Signatures/HttpRequestMessageExtensions.cs
+++ b/src/Decos.Http.Signatures/HttpRequestMessageExtensions.cs
@@ -30,8 +30,8 @@ namespace Decos.Http.Signatures
             string scheme = "Signature")
         {
             var stream = request.Content != null ? await request.Content.ReadAsStreamAsync().ConfigureAwait(false) : null;
-            var hash = signatureAlgorithm.CalculateHash(request.Method.ToString(),
-                request.RequestUri.OriginalString, stream, out var nonce, out var timestamp);
+            var (hash, nonce, timestamp) = await signatureAlgorithm.CalculateHashAsync(request.Method.ToString(),
+                request.RequestUri.OriginalString, stream, default);
 
             var param = new HttpSignature
             {

--- a/src/Decos.Http.Signatures/HttpSignatureAlgorithm.cs
+++ b/src/Decos.Http.Signatures/HttpSignatureAlgorithm.cs
@@ -106,7 +106,7 @@ namespace Decos.Http.Signatures
         }
 
         /// <summary>
-        /// Calculates a new signature for the specified parameters, using a new nonce and
+        /// Calculates a new signature for the specified parameters, generating a new nonce and
         /// timestamp.
         /// </summary>
         /// <param name="method">The HTTP method of the message.</param>
@@ -126,7 +126,7 @@ namespace Decos.Http.Signatures
         /// </list>
         /// </returns>
         public async Task<(byte[] hash, string nonce, DateTimeOffset timestamp)> CalculateHashAsync(
-            string method, string uri, Stream stream, CancellationToken cancellationToken)
+            string method, string uri, Stream stream, CancellationToken cancellationToken = default)
         {
             var nonce = Guid.NewGuid().ToString();
             var timestamp = Clock.UtcNow;
@@ -180,7 +180,7 @@ namespace Decos.Http.Signatures
         /// <paramref name="nonce"/> or <paramref name="timestamp"/> are not specified.
         /// </exception>
         public async Task<byte[]> CalculateHashAsync(string method, string uri, Stream stream,
-            string nonce, DateTimeOffset timestamp, CancellationToken cancellationToken)
+            string nonce, DateTimeOffset timestamp, CancellationToken cancellationToken = default)
         {
             if (method == null)
                 throw new ArgumentNullException(nameof(method));

--- a/src/Decos.Http.Signatures/HttpSignatureAlgorithm.cs
+++ b/src/Decos.Http.Signatures/HttpSignatureAlgorithm.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
 using Microsoft.Extensions.Logging;
 
 namespace Decos.Http.Signatures
@@ -10,6 +13,16 @@ namespace Decos.Http.Signatures
     /// </summary>
     public class HttpSignatureAlgorithm
     {
+        private const int ContentBufferSize = 8192;
+
+        private static readonly byte[] s_emptyHash = new byte[]
+        {
+            0xE3, 0xB0, 0xC4, 0x42, 0x98, 0xFC, 0x1C, 0x14,
+            0x9A, 0xFB, 0xF4, 0xC8, 0x99, 0x6F, 0xB9, 0x24,
+            0x27, 0xAE, 0x41, 0xE4, 0x64, 0x9B, 0x93, 0x4C,
+            0xA4, 0x95, 0x99, 0x1B, 0x78, 0x52, 0xB8, 0x55
+        };
+
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpSignatureAlgorithm"/> class with the
         /// specified key.
@@ -70,7 +83,8 @@ namespace Decos.Http.Signatures
         protected ILogger Logger { get; }
 
         /// <summary>
-        /// Calculates a new signature for the specified parameters, using a new nonce and timestamp.
+        /// Calculates a new signature for the specified parameters, using a new nonce and
+        /// timestamp.
         /// </summary>
         /// <param name="method">The HTTP method of the message.</param>
         /// <param name="uri">The request URI of the message.</param>
@@ -82,12 +96,42 @@ namespace Decos.Http.Signatures
         /// When this method returns, contains the point in time the signature was created.
         /// </param>
         /// <returns>A byte array that contains the calculated signature hash.</returns>
+        [Obsolete("Use " + nameof(CalculateHashAsync) + " instead.")]
         public byte[] CalculateHash(string method, string uri, Stream stream,
             out string nonce, out DateTimeOffset timestamp)
         {
             nonce = Guid.NewGuid().ToString();
             timestamp = Clock.UtcNow;
             return CalculateHash(method, uri, stream, nonce, timestamp);
+        }
+
+        /// <summary>
+        /// Calculates a new signature for the specified parameters, using a new nonce and
+        /// timestamp.
+        /// </summary>
+        /// <param name="method">The HTTP method of the message.</param>
+        /// <param name="uri">The request URI of the message.</param>
+        /// <param name="stream">A stream that contains the message body.</param>
+        /// <param name="cancellationToken">
+        /// A token used to monitor for cancellation requests.
+        /// </param>
+        /// <returns>
+        /// A task that returns a tuple containing the following items:
+        /// <list type="number">
+        /// <item>a byte array that contains the calculated signature hash;</item>
+        /// <item>a string that contains the nonce used;</item>
+        /// <item>
+        /// a DateTimeOffset that represents the point in time the signature was created.
+        /// </item>
+        /// </list>
+        /// </returns>
+        public async Task<(byte[] hash, string nonce, DateTimeOffset timestamp)> CalculateHashAsync(
+            string method, string uri, Stream stream, CancellationToken cancellationToken)
+        {
+            var nonce = Guid.NewGuid().ToString();
+            var timestamp = Clock.UtcNow;
+            var hash = await CalculateHashAsync(method, uri, stream, nonce, timestamp, cancellationToken).ConfigureAwait(false);
+            return (hash, nonce, timestamp);
         }
 
         /// <summary>
@@ -106,8 +150,37 @@ namespace Decos.Http.Signatures
         /// <exception cref="ArgumentException">
         /// <paramref name="nonce"/> or <paramref name="timestamp"/> are not specified.
         /// </exception>
+        [Obsolete("Use " + nameof(CalculateHashAsync) + " instead.")]
         public byte[] CalculateHash(string method, string uri, Stream stream,
             string nonce, DateTimeOffset timestamp)
+        {
+            return CalculateHashAsync(method, uri, stream, nonce, timestamp, default)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Calculates a new signature for the specified parameters using the specified nonce and
+        /// timestamp.
+        /// </summary>
+        /// <param name="method">The HTTP method of the message.</param>
+        /// <param name="uri">The request URI of the message.</param>
+        /// <param name="stream">A stream that contains the message body.</param>
+        /// <param name="nonce">The nonce used to calculate the signature.</param>
+        /// <param name="timestamp">The point in time the signature was created.</param>
+        /// <param name="cancellationToken">
+        /// A token used to monitor for cancellation requests.
+        /// </param>
+        /// <returns>
+        /// A task that returns a byte array that contains the calculated signature hash.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="method"/> or <paramref name="uri"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="nonce"/> or <paramref name="timestamp"/> are not specified.
+        /// </exception>
+        public async Task<byte[]> CalculateHashAsync(string method, string uri, Stream stream,
+            string nonce, DateTimeOffset timestamp, CancellationToken cancellationToken)
         {
             if (method == null)
                 throw new ArgumentNullException(nameof(method));
@@ -121,7 +194,7 @@ namespace Decos.Http.Signatures
             if (timestamp == default)
                 throw new ArgumentException("A timestamp must be specified.", nameof(timestamp));
 
-            var contentHash = CalculateContentHash(stream);
+            var contentHash = await CalculateContentHashAsync(stream, cancellationToken).ConfigureAwait(false);
             var signatureData = new SignatureData(method, uri, nonce, timestamp, contentHash);
             Logger?.LogDebug("Calculating a signature with the following data: {Data}", signatureData);
             return CalculateHash(signatureData);
@@ -145,17 +218,35 @@ namespace Decos.Http.Signatures
         /// Calculates a general purpose hash of the stream's content.
         /// </summary>
         /// <param name="stream">
-        /// The stream whose content is used to calculate a hash. If seeking is supported, the stream
-        /// is reset to its original position when this method returns.
+        /// The stream whose content is used to calculate a hash. If seeking is supported, the
+        /// stream is reset to its original position when this method returns.
         /// </param>
         /// <returns>A byte array that contains the calculated hash.</returns>
+        [Obsolete("Use " + nameof(CalculateContentHashAsync) + " instead.")]
         protected byte[] CalculateContentHash(Stream stream)
+        {
+            return CalculateContentHashAsync(stream, default)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Calculates a general purpose hash of the stream's content.
+        /// </summary>
+        /// <param name="stream">
+        /// The stream whose content is used to calculate a hash. If seeking is supported, the
+        /// stream is reset to its original position when this method returns.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A token used to monitor for cancellation requests.
+        /// </param>
+        /// <returns>A task that returns a byte array that contains the calculated hash.</returns>
+        protected async Task<byte[]> CalculateContentHashAsync(Stream stream, CancellationToken cancellationToken)
         {
             byte[] contentHash;
             using (var sha256 = SHA256.Create())
             {
                 if (stream == null)
-                    return sha256.ComputeHash(new byte[0]);
+                    return s_emptyHash;
 
                 long? offset = null;
                 if (stream.CanSeek)
@@ -164,7 +255,10 @@ namespace Decos.Http.Signatures
                     stream.Seek(0, SeekOrigin.Begin);
                 }
 
-                contentHash = sha256.ComputeHash(stream);
+                var buffer = new byte[ContentBufferSize];
+                var bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
+                    .ConfigureAwait(false);
+                contentHash = sha256.ComputeHash(buffer, 0, bytesRead);
 
                 if (stream.CanSeek && offset != null)
                     stream.Seek(offset.Value, SeekOrigin.Begin);

--- a/tests/Decos.Http.Signatures.Validation.Tests/AsyncOnlyStringStream.cs
+++ b/tests/Decos.Http.Signatures.Validation.Tests/AsyncOnlyStringStream.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Decos.Http.Signatures.Tests;
+
+namespace Decos.Http.Signatures.Validation.Tests
+{
+    internal class AsyncOnlyStringStream : StringStream
+    {
+        public AsyncOnlyStringStream(string value)
+            : base(value)
+        {
+        }
+
+        public AsyncOnlyStringStream(string value, Encoding encoding)
+            : base(value, encoding)
+        {
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length
+            => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int WriteTimeout
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw SyncDisallowed();
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) 
+            => Task.FromResult(base.Read(buffer, offset, count));
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        private InvalidOperationException SyncDisallowed()
+            => new InvalidOperationException("Synchronous operations are disallowed.");
+    }
+}

--- a/tests/Decos.Http.Signatures.Validation.Tests/HttpSignatureValidatorTests.cs
+++ b/tests/Decos.Http.Signatures.Validation.Tests/HttpSignatureValidatorTests.cs
@@ -191,6 +191,17 @@ namespace Decos.Http.Signatures.Validation.Tests
             result2.Should().Be(SignatureValidationResult.OK);
         }
 
+        [Fact]
+        public async Task SignatureClientCorrectlyValidatesIfStreamIsAsyncOnly()
+        {
+            var validator = CreateValidator();
+            var signature = GetTestSignature();
+
+            var result = await validator.ValidateAsync(signature, TestMethod, TestUri, new AsyncOnlyStringStream(""));
+
+            result.Should().Be(SignatureValidationResult.OK);
+        }
+
         private HttpSignature GetTestSignature()
         {
             return new HttpSignature


### PR DESCRIPTION
This should avoid the need to explicitly allow Synchronous IO on ASP.NET Core 3.x. 

Unfortunately, there is no ComputeHashAsync (but this [has been proposed](https://github.com/dotnet/corefx/pull/42565)). To work around this, we read the stream first and calculate the hash of the stream content over the buffer. To prevent memory issues, we limit this buffer to the first 8192 bytes of the stream.